### PR TITLE
UseItem IL hooks now correctly return bool? instead of bool.

### DIFF
--- a/Core/ILEditingStuff/MechanicHooks.cs
+++ b/Core/ILEditingStuff/MechanicHooks.cs
@@ -740,6 +740,7 @@ namespace InfernumMode.Core.ILEditingStuff
                 }
             });
             cursor.Emit(OpCodes.Ldc_I4_1);
+            cursor.Emit(OpCodes.Newobj, typeof(bool?).GetConstructor([typeof(bool)]));
             cursor.Emit(OpCodes.Ret);
         }
     }
@@ -842,6 +843,7 @@ namespace InfernumMode.Core.ILEditingStuff
                     Utilities.NewProjectileBetter(player.Center, Vector2.Zero, ModContent.ProjectileType<GuardiansSummonerProjectile>(), 0, 0f);
             });
             cursor.Emit(OpCodes.Ldc_I4_1);
+            cursor.Emit(OpCodes.Newobj, typeof(bool?).GetConstructor([typeof(bool)]));
             cursor.Emit(OpCodes.Ret);
         }
     }

--- a/Core/ILEditingStuff/VanillaCorrectionHooks.cs
+++ b/Core/ILEditingStuff/VanillaCorrectionHooks.cs
@@ -837,6 +837,7 @@ namespace InfernumMode.Core.ILEditingStuff
                 }
             });
             cursor.Emit(OpCodes.Ldc_I4_1);
+            cursor.Emit(OpCodes.Newobj, typeof(bool?).GetConstructor([typeof(bool)]));
             cursor.Emit(OpCodes.Ret);
         }
     }


### PR DESCRIPTION
`UseItem` should return `bool?` instead of `bool`, so `ldc.i4.1` and immediate `ret` can cause problems. In fact, `ItemLoader.UseItem` thinks it returned `false`. This PR solves the problem.