### PR TITLE
Fix Rune of Kos bug

### DIFF
--- a/Content/BehaviorOverrides/BossAIs/StormWeaver/StormWeaverHeadBehaviorOverride.cs
+++ b/Content/BehaviorOverrides/BossAIs/StormWeaver/StormWeaverHeadBehaviorOverride.cs
@@ -960,6 +960,9 @@ namespace InfernumMode.Content.BehaviorOverrides.BossAIs.StormWeaver
             ref float attackState = ref npc.ai[1];
             ref float attackCycleIndex = ref npc.Infernum().ExtraAI[5];
 
+            if (attackState == (int)StormWeaverAttackType.HuntSkyCreatures)
+                npc.Opacity = 1f;
+
             attackCycleIndex++;
             switch ((int)attackCycleIndex % 6)
             {

--- a/Core/ILEditingStuff/MechanicHooks.cs
+++ b/Core/ILEditingStuff/MechanicHooks.cs
@@ -687,6 +687,7 @@ namespace InfernumMode.Core.ILEditingStuff
                             CalamityUtils.SpawnBossBetter(player.Center, ModContent.NPCType<CeaselessVoid>(), new ExactPositionBossSpawnContext(), (int)CeaselessVoidBehaviorOverride.CeaselessVoidAttackType.DarkEnergySwirl, 0f, 0f, 1f);
                         else
                             NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<CeaselessVoid>());
+                        return false;
                     }
                 }
                 else if (player.ZoneUnderworldHeight)
@@ -712,6 +713,7 @@ namespace InfernumMode.Core.ILEditingStuff
                             NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<Signus>());
                         else
                             NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<Signus>());
+                        return false;
                     }
                 }
                 else if (player.ZoneSkyHeight)
@@ -736,10 +738,12 @@ namespace InfernumMode.Core.ILEditingStuff
                             NPC.SpawnOnPlayer(player.whoAmI, ModContent.NPCType<StormWeaverHead>());
                         else
                             NetMessage.SendData(MessageID.SpawnBossUseLicenseStartEvent, -1, -1, null, player.whoAmI, ModContent.NPCType<StormWeaverHead>());
+                        return false;
                     }
                 }
+
+                return true;
             });
-            cursor.Emit(OpCodes.Ldc_I4_1);
             cursor.Emit(OpCodes.Newobj, typeof(bool?).GetConstructor([typeof(bool)]));
             cursor.Emit(OpCodes.Ret);
         }


### PR DESCRIPTION
There seems to be a [bug](https://github.com/InfernumTeam/InfernumMode/pull/13#issuecomment-2110249601) exposed by my fix. Rune of Kos originally seemed to work correctly because `UseItem` effectively returned `false`, causing the item to be used more than twice extremely rapidly. It didn't gave time for the hunt phase to decrease `Opacity` which makes the Storm Weaver invulnerable, and immediately changed to attack phase. 

There are three approaches which I can think of.
1. Return `false` for summoning, `true` for angering. This is the hackiest and the shortest solution.
2. Hook `NPC.SpawnOnPlayer` and add angering mechanic.
3. Anger immediately after spawning if not `MultiplayerClient`. Use `HijackGetData` to separately deal with `MultiplayerClient`.

This PR uses the first solution.