### PR TITLE
Fix firestorm projectiles being drawn off-center

### DIFF
--- a/Content/BehaviorOverrides/BossAIs/SupremeCalamitas/AcceleratingDarkMagicFlame.cs
+++ b/Content/BehaviorOverrides/BossAIs/SupremeCalamitas/AcceleratingDarkMagicFlame.cs
@@ -54,7 +54,7 @@ namespace InfernumMode.Content.BehaviorOverrides.BossAIs.SupremeCalamitas
 
         public override bool PreDraw(ref Color lightColor)
         {
-            Utilities.DrawAfterimagesCentered(Projectile, Color.White, ProjectileID.Sets.TrailingMode[Projectile.type], 1, TextureAssets.Projectile[Projectile.type].Value, false);
+            Utilities.DrawAfterimagesCentered(Projectile, Color.White, ProjectileID.Sets.TrailingMode[Projectile.type], 1, TextureAssets.Projectile[Projectile.type].Value);
             return false;
         }
     }


### PR DESCRIPTION
Currently, the accelerating fireballs in SCal's firestorm attack have their sprites drawn centered on the top-left corner of the hitbox instead of the center, due to setting the `drawCentered` parameter in the afterimages function to false. This simply fixes that by removing the false, causing it to use the default argument of true.