### PR TITLE
Fix Dark Soul hitbox being off center

### DIFF
--- a/Content/BehaviorOverrides/BossAIs/SupremeCalamitas/RedirectingDarkSoul.cs
+++ b/Content/BehaviorOverrides/BossAIs/SupremeCalamitas/RedirectingDarkSoul.cs
@@ -61,7 +61,7 @@ namespace InfernumMode.Content.BehaviorOverrides.BossAIs.SupremeCalamitas
 
         public override bool PreDraw(ref Color lightColor)
         {
-            Utilities.DrawAfterimagesCentered(Projectile, Color.White, ProjectileID.Sets.TrailingMode[Projectile.type], 1, TextureAssets.Projectile[Projectile.type].Value, false);
+            Utilities.DrawAfterimagesCentered(Projectile, Color.White, ProjectileID.Sets.TrailingMode[Projectile.type], 1, TextureAssets.Projectile[Projectile.type].Value);
             return false;
         }
     }


### PR DESCRIPTION
Fix is identical in nature to Congrats' firestorm fix. Makes the hitbox more accurate. Size remains unchanged.