### PR TITLE
Fix Nighttime Providence speed/acceleration buff getting applied twice

### DIFF
--- a/Content/BehaviorOverrides/BossAIs/Providence/ProvidenceBehaviorOverride.cs
+++ b/Content/BehaviorOverrides/BossAIs/Providence/ProvidenceBehaviorOverride.cs
@@ -2529,13 +2529,6 @@ namespace InfernumMode.Content.BehaviorOverrides.BossAIs.Providence
                 acceleration *= 1.35f;
             }
 
-            // Fly faster at night.
-            if (IsEnraged)
-            {
-                maxFlySpeed *= 1.35f;
-                acceleration *= 1.35f;
-            }
-
             // Don't stray too far from the target.
             npc.velocity.X = Clamp(npc.velocity.X + flightPath * acceleration, -maxFlySpeed, maxFlySpeed);
             if (verticalDistanceFromTarget < 50f)


### PR DESCRIPTION
Currently speed and acceleration are multipled by 1.35 and then multiplied by 1.35 again.
This simply removes the duplicate code.  