### PR TITLE
Fixed(?) Profaned Guardians fight in multiplayer.

### DIFF
--- a/Content/BehaviorOverrides/BossAIs/ProfanedGuardians/HealerShieldCrystal.cs
+++ b/Content/BehaviorOverrides/BossAIs/ProfanedGuardians/HealerShieldCrystal.cs
@@ -1,4 +1,3 @@
-﻿using System.Security.Policy;
 using CalamityMod;
 using CalamityMod.NPCs;
 using CalamityMod.Particles;

--- a/Content/BehaviorOverrides/BossAIs/ProfanedGuardians/HealerShieldCrystal.cs
+++ b/Content/BehaviorOverrides/BossAIs/ProfanedGuardians/HealerShieldCrystal.cs
@@ -1,4 +1,5 @@
-﻿using CalamityMod;
+﻿using System.Security.Policy;
+using CalamityMod;
 using CalamityMod.NPCs;
 using CalamityMod.Particles;
 using InfernumMode.Assets.Effects;
@@ -100,6 +101,15 @@ namespace InfernumMode.Content.BehaviorOverrides.BossAIs.ProfanedGuardians
 
         public void DoBehavior_SitStill(Player target)
         {
+            /* Akira 5/18/2026: this is the only thing mp patch does for the guadians to "fix" them. the MP patch claims that in multiplayer the crystal sometimes just doesn't spawn and this
+               small change fixes it. after testing with this patch, nothing seems to break, and the only thing i noticed was the healer guaridan in mp seems to like to try to run away at the 
+               very start of the fight but does end up in it's correct pos after a second; the rest of the fight seems to work fine in multiplayer as well. */
+            if (Main.netMode == NetmodeID.Server)
+            {
+                if (ShatteringTimer % 150 == 0)
+                    NPC.netUpdate = true;
+            }
+
             // If the target is close enough, take damage.
             if (target.WithinRange(NPC.Center * NPC.Opacity, 1000))
                 NPC.dontTakeDamage = false;


### PR DESCRIPTION
This patch fixes a bug that caused the healer shield crystal not to spawn in multiplayer properly, which presumably is what breaks the fight. Testing with this patch allowed me to fight the fight fine* in multiplayer, and I encountered no issues; however, that was with me using localhost, so this is in a near-perfect world with no real server delay.

*There is a small issue where the healer guardian runs away at the very start of the fight, but it does make its way back to its intended spot after a second.