### PR TITLE
MP Patches Round 3

### DIFF
--- a/Content/BehaviorOverrides/BossAIs/AquaticScourge/AquaticScourgeHeadBehaviorOverride.cs
+++ b/Content/BehaviorOverrides/BossAIs/AquaticScourge/AquaticScourgeHeadBehaviorOverride.cs
@@ -234,17 +234,17 @@ namespace InfernumMode.Content.BehaviorOverrides.BossAIs.AquaticScourge
             bool enraged = !target.IsUnderwater() && !phase3 && !BossRushEvent.BossRushActive;
 
             // Disable obnoxious water mechanics so that the player can fight the boss without interruption.
-            if (!target.Calamity().ZoneAbyss && (AquaticScourgeAttackType)attackType != AquaticScourgeAttackType.DeathAnimation)
+            foreach (Player player in Main.ActivePlayers)
             {
-                target.breath = target.breathMax;
-                target.ignoreWater = true;
+                if (player.dead || player.ghost || !npc.WithinRange(player.Center, 10000f))
+                    continue;
 
-                // Give targets infinite flight time.
-                foreach (Player player in Main.ActivePlayers)
+                if (!player.Calamity().ZoneAbyss && (AquaticScourgeAttackType)attackType != AquaticScourgeAttackType.DeathAnimation)
                 {
-                    if (player.dead || player.ghost || !npc.WithinRange(player.Center, 10000f))
-                        continue;
+                    player.breath = player.breathMax;
+                    player.ignoreWater = true;
 
+                    // Give targets infinite flight time.
                     player.DoInfiniteFlightCheck(Color.Lime);
                 }
             }

--- a/Content/BehaviorOverrides/BossAIs/CalamitasShadow/CataclysmBehaviorOverride.cs
+++ b/Content/BehaviorOverrides/BossAIs/CalamitasShadow/CataclysmBehaviorOverride.cs
@@ -106,14 +106,16 @@ namespace InfernumMode.Content.BehaviorOverrides.BossAIs.CalamitasShadow
                 CalamityGlobalNPC.catastrophe = npc.whoAmI;
 
                 // Use a fallback target if Cataclysm doesn't have one at the moment. This will not care about large distances.
-                npc.TargetClosestIfTargetIsInvalid(1000000f);
+                npc.target = Main.npc[CalamityGlobalNPC.calamitas].target;
+                //npc.TargetClosestIfTargetIsInvalid(1000000f);
             }
 
             // Have Cataclysm increment the attack timer and handle targeting.
             else if (isCataclysm)
             {
                 CalamityGlobalNPC.cataclysm = npc.whoAmI;
-                npc.TargetClosestIfTargetIsInvalid();
+                npc.target = Main.npc[CalamityGlobalNPC.calamitas].target; //This prevents the brothers targeting a different player than the one CalShadow is since if CalShadow targets a
+                                                                           //different player the soul seekers don't follow the player the brothers are targeting
                 attackTimer++;
 
                 CataclysmEnergyDrawer.Update();

--- a/Core/GlobalInstances/CustomNPCDataSyncing.cs
+++ b/Core/GlobalInstances/CustomNPCDataSyncing.cs
@@ -1,5 +1,10 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
+using CalamityMod.NPCs.CalClone;
 using Terraria;
+using Terraria.ModLoader.IO;
+using Terraria.ModLoader;
+using CalamityMod.NPCs.SupremeCalamitas;
 
 namespace InfernumMode.Core.GlobalInstances
 {
@@ -15,6 +20,25 @@ namespace InfernumMode.Core.GlobalInstances
             {
                 if (ExtraAI[i] != 0f)
                     HasAssociatedAIBeenUsed[i] = true;
+            }
+        }
+
+        /* Akira: I didn't know if there was a better place to put this, but felt like it made the most sense. 
+         * This seems to fix a lot of jitter with the brothers, and MP patch claims the following lines below:
+              Catastrophe sets its ai to refer to cataclysm's ai[], which causes problems when that NPC disappears and is replaced with another.
+              In multiplayer, receiving info of a new NPC does not create a new array with the new ai values, but instead replaces the contents.
+              Gradually, more and more NPCs share the same ai as the reference is never undone and you are henceforth cursed forever. */
+        public override void SendExtraAI(NPC npc, BitWriter bitWriter, BinaryWriter binaryWriter)
+        {
+        }
+        public override void ReceiveExtraAI(NPC npc, BitReader bitReader, BinaryReader binaryReader)
+        {
+            if (npc.type == ModContent.NPCType<Cataclysm>() || npc.type == ModContent.NPCType<Catastrophe>() || npc.type == ModContent.NPCType<SupremeCataclysm>() || npc.type == ModContent.NPCType<SupremeCatastrophe>())
+            {
+                if (!npc.active)
+                {
+                    npc.ai = new float[NPC.maxAI];
+                }
             }
         }
     }


### PR DESCRIPTION
- Fixed Aquatic Scourge only giving its target full breath and water movement immunity
- Improved targeting on CalShadow brothers to be better in multiplayer
- Fixed CalShadow and SCal brothers acting weird sometimes.