### PR TITLE
Fix EditEnrageTooltips breaking tooltip modifications in non-English localizations

### DIFF
--- a/Core/GlobalInstances/GlobalItems/TooltipChangeGlobalItem.cs
+++ b/Core/GlobalInstances/GlobalItems/TooltipChangeGlobalItem.cs
@@ -192,7 +192,11 @@ namespace InfernumMode.Core.GlobalInstances.GlobalItems
             if (enrageTooltip is null)
                 return;
 
-            int enrageTextStart = enrageTooltip.Text.IndexOf("enrage", StringComparison.OrdinalIgnoreCase);
+            int enrageTextStart = enrageTooltip.Text.IndexOf(localizedEnrageText, StringComparison.OrdinalIgnoreCase);
+            int lineStart = enrageTooltip.Text.LastIndexOf('\n', Math.Max(enrageTextStart - 1, 0));
+            
+            enrageTextStart = lineStart == -1 ? 0 : lineStart + 1;
+
             int enrageTextEnd = enrageTextStart;
 
             // Find where the current line terminates following the instance of the word 'enrage'.


### PR DESCRIPTION
Fixes #69

## Fix

- Search using the localized anchor text (`localizedEnrageText`) instead of the hardcoded `"enrage"`.
- Backtrack from the matched index to the start of the line (previous `\n`, or the start of the string) before cutting, instead of assuming the match index is already the line start.

## Tests

Tested with a Spanish localization where the anchor word (`enfurecer`) appears mid-sentence. 
Before the fix: tooltip either crashed or left a dangling fragment (e.g. `Se ` left over).
After the fix: tooltip is replaced/removed cleanly, matching the behavior already seen in English. 
English works as intended too.